### PR TITLE
Add feature to allow user to choose number of comments to display

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -38,9 +38,7 @@ import java.util.ArrayList;
 public class DataServlet extends HttpServlet {
 
   @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    List<Comment> data = new ArrayList<>(); 
-    
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {  
     String numParam = request.getParameter("num");
     int numParsed = Integer.parseInt(numParam); // the number of comments the user wants
 
@@ -48,16 +46,6 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     PreparedQuery results = datastore.prepare(query);
-
-    // for (Entity entity : results.asList(FetchOptions.Builder.withLimit(numParsed))) {
-    //   long id = entity.getKey().getId();
-    //   String content = (String) entity.getProperty("content");
-    //   String name = (String) entity.getProperty("name");
-    //   long timestamp = (long) entity.getProperty("timestamp");
-
-    //   Comment comment = new Comment(id, content, name, timestamp);
-    //   data.add(comment);
-    // }
 
     Gson gson = new Gson();
     String json = gson.toJson(results.asList(FetchOptions.Builder.withLimit(numParsed))); 
@@ -88,24 +76,5 @@ public class DataServlet extends HttpServlet {
     datastore.put(commentEntity);   
 
     response.sendRedirect("/"); 
-  }
-
-  /** Inner class that stores a comment object
-   * id is the Datastore generated id, content is the content of the comment,
-   * name is the name of the user who made the comment, 
-   * and timestamp is the time the comment was made (as a long)
-   */
-  class Comment {
-    private final long id;
-    private final String content;
-    private final String name;
-    private final long timestamp;
-    
-    public Comment(long id, String content, String name, long timestamp) {
-      this.id = id;
-      this.content = content;
-      this.name = name;
-      this.timestamp = timestamp; 
-    }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -51,18 +51,18 @@ public class DataServlet extends HttpServlet {
 
     PreparedQuery results = datastore.prepare(query);
 
-    for (Entity entity : results.asList(FetchOptions.Builder.withLimit(numParsed))) {
-      long id = entity.getKey().getId();
-      String content = (String) entity.getProperty("content");
-      String name = (String) entity.getProperty("name");
-      long timestamp = (long) entity.getProperty("timestamp");
+    // for (Entity entity : results.asList(FetchOptions.Builder.withLimit(numParsed))) {
+    //   long id = entity.getKey().getId();
+    //   String content = (String) entity.getProperty("content");
+    //   String name = (String) entity.getProperty("name");
+    //   long timestamp = (long) entity.getProperty("timestamp");
 
-      Comment comment = new Comment(id, content, name, timestamp);
-      data.add(comment);
-    }
+    //   Comment comment = new Comment(id, content, name, timestamp);
+    //   data.add(comment);
+    // }
 
     Gson gson = new Gson();
-    String json = gson.toJson(data); 
+    String json = gson.toJson(results.asList(FetchOptions.Builder.withLimit(numParsed))); 
 
     response.setContentType("application/json;");
     response.getWriter().println(json);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -24,14 +24,10 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.Enumeration;
-import java.util.Enumeration;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.List; 
-import java.util.ArrayList; 
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -17,11 +17,15 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.FetchOptions.Builder;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
-import java.io.IOException;
 import com.google.gson.Gson;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Enumeration;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -39,11 +43,15 @@ public class DataServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
      data = new ArrayList<>(); 
     
+    String numParam = request.getParameter("num");
+    int numParsed = Integer.parseInt(numParam); // the number of comments the user wants
+
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     PreparedQuery results = datastore.prepare(query);
-    for (Entity entity : results.asIterable()) {
+
+    for (Entity entity : results.asList(FetchOptions.Builder.withLimit(numParsed))) {
       long id = entity.getKey().getId();
       String content = (String) entity.getProperty("content");
       String name = (String) entity.getProperty("name");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -36,6 +36,12 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {  
     String numParam = request.getParameter("num");
+    
+    if (numParam == null) {
+      response.sendError(400);
+      return;
+    }
+
     int numParsed = Integer.parseInt(numParam); // the number of comments the user wants
 
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -167,6 +167,12 @@
         <!-- Container with button to get a message -->
         <div id="comment-container" class="container">
           <h2>Comments</h2>
+          <select id="num-comments">
+            <option value=1 selected>1</option>
+            <option value=3>3</option>
+            <option value=5>5</option>
+            <option value=10>10</option>
+          </select>
           <button onClick="fetchFromData()" id="get-msg-btn">Show Comments</button>
           <button onClick="hideComments()" class="invisible" id="hide-msg-btn">Hide Comments</button>
           <div id="all-messages"></div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -63,7 +63,6 @@ async function fetchFromData() {
   
   // This gives a list of comments
   const comments = await response.json();
-  const numComments = comments.length;
 
   const root = $("#all-messages");
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -63,13 +63,14 @@ async function fetchFromData() {
   
   // This gives a list of comments
   const comments = await response.json();
+  console.log(comments);
   const numComments = comments.length;
 
   const root = document.getElementById("all-messages");
 
   // Adds all of the messages to a div
   comments.forEach(c => {
-    root.appendChild(createCommentElement(c)); 
+    root.appendChild(createCommentElement(c.propertyMap)); 
   }); 
 
   $("#get-msg-btn").addClass("invisible"); 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -63,7 +63,6 @@ async function fetchFromData() {
   
   // This gives a list of comments
   const comments = await response.json();
-  console.log(comments);
   const numComments = comments.length;
 
   const root = $("#all-messages");

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -70,7 +70,7 @@ async function fetchFromData() {
 
   // Adds all of the messages to a div
   comments.forEach(c => {
-    root.appendChild(createCommentElement(c.propertyMap)); 
+    root.append(createCommentElement(c.propertyMap)); 
   }); 
 
   $("#get-msg-btn").addClass("invisible"); 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -55,22 +55,20 @@ function loadSkills () {
  * Makes a request to /data and gets the response
  */
 async function fetchFromData() {
-  const response = await fetch('/data');
+  const selector = $("#num-comments")[0]; //get the select element
+  const selectedNum = selector.options[selector.selectedIndex].value; //number of comments user wants
+
+  //make request with the number specified
+  const response = await fetch(`/data?num=${selectedNum}`);
   
-  // This gives a list of messages
+  // This gives a list of comments
   const comments = await response.json();
   const numComments = comments.length;
-  const selector = $("#num-comments")[0]; //get the select element
-  const selected = selector.options[selector.selectedIndex].value; //number of comments user wants
-  console.log(selected)
-
-  //the first selected number of comments (most recent first)
-  const commentsNeeded = selected >= numComments ? comments : comments.slice(0, selected);
 
   const root = document.getElementById("all-messages");
 
   // Adds all of the messages to a div
-  commentsNeeded.forEach(c => {
+  comments.forEach(c => {
     root.appendChild(createCommentElement(c)); 
   }); 
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -59,11 +59,18 @@ async function fetchFromData() {
   
   // This gives a list of messages
   const comments = await response.json();
+  const numComments = comments.length;
+  const selector = $("#num-comments")[0]; //get the select element
+  const selected = selector.options[selector.selectedIndex].value; //number of comments user wants
+  console.log(selected)
+
+  //the first selected number of comments (most recent first)
+  const commentsNeeded = selected >= numComments ? comments : comments.slice(0, selected);
 
   const root = document.getElementById("all-messages");
 
   // Adds all of the messages to a div
-  comments.forEach(c => {
+  commentsNeeded.forEach(c => {
     root.appendChild(createCommentElement(c)); 
   }); 
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -55,8 +55,7 @@ function loadSkills () {
  * Makes a request to /data and gets the response
  */
 async function fetchFromData() {
-  const selector = $("#num-comments")[0]; //get the select element
-  const selectedNum = selector.options[selector.selectedIndex].value; //number of comments user wants
+  const selectedNum = $("#num-comments").val(); //the number of comments the user wants
 
   //make request with the number specified
   const response = await fetch(`/data?num=${selectedNum}`);


### PR DESCRIPTION
Add a select menu to index that lets user decide how many comments to see and displays at most the number. 

Added a query parameter when making a request to the server so that the server only queries up to that many. Removed the work of slicing the queried results from the client.

![image](https://user-images.githubusercontent.com/48307028/83675465-ac28eb00-a59e-11ea-945f-66497c0b70d7.png)
![image](https://user-images.githubusercontent.com/48307028/83675507-be0a8e00-a59e-11ea-9868-ea319c146461.png)
